### PR TITLE
Feature/update names

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,6 @@
 
 ### Credit
 
+This is a fork of the [Mars Wallet Connector](https://github.com/mars-protocol/wallet-connector) repo maintained by Y-Foundry-DAO
+
 This connector was build on the codebase of [Noah Saso's cosmodal repository](https://www.npmjs.com/package/@noahsaso/cosmodal "Noah Saso cosmodal repository"). Big 'thank you' for creating this awesome piece of code from Mars!

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "@marsprotocol/wallet-connector",
+  "name": "@y-foundry-dao/wallet-connector",
   "version": "0.9.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mars-protocol/wallet-connector.git"
+    "url": "git+https://github.com/y-foundry-dao/wallet-connector.git"
   },
-  "author": "Mars Protcol",
+  "author": "Y-Foundry-DAO",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/mars-protocol/wallet-connector/issues"
+    "url": "https://github.com/y-foundry-dao/wallet-connector/issues"
   },
-  "homepage": "https://github.com/mars-protocol/wallet-connector#readme",
+  "homepage": "https://github.com/y-foundry-dao/wallet-connector#readme",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "unpkg": "dist/index.js",


### PR DESCRIPTION
Changed 'marsprotocol' to 'y-foundry-dao' across package.json and attributed mars protocol in the readme since this is a fork of an ISC licensed project.